### PR TITLE
Fix: command palette URL and focus reliability

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -18,24 +18,32 @@
 	let query = $state('');
 	let activeIndex = $state(0);
 	let copied = $state(false);
-	let inputEl = $state<HTMLInputElement | null>(null);
 	let listEl = $state<HTMLElement | null>(null);
 
-	// goto() alone can't handle same-page hash targets, and the palette's
-	// scroll lock must be released before any scrolling — see execute().
+	// Focus synchronously on mount — a rAF-deferred focus can lose the
+	// user's first keystrokes if the browser is busy (e.g. mid smooth-scroll)
+	function autofocus(node: HTMLInputElement) {
+		node.focus();
+	}
+
+	// goto() with the full path keeps the URL (including hash) correct.
+	// noScroll + manual scrollIntoView handles the cases goto won't:
+	// re-selecting the section already in the URL, and smooth scrolling.
+	// The palette's scroll lock must be released first — see execute().
 	async function navigate(path: string) {
-		const [route, hash] = path.split('#');
-		const target = route || '/';
-		if (window.location.pathname !== target) {
-			await goto(target);
-		}
-		if (hash) {
+		const hash = path.split('#')[1];
+		await goto(path, { noScroll: true });
+		// Double rAF: SvelteKit applies its own (noScroll) scroll restoration
+		// in the frame after goto resolves; scrolling before that gets undone.
+		requestAnimationFrame(() => {
 			requestAnimationFrame(() => {
-				document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' });
+				if (hash) {
+					document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' });
+				} else {
+					window.scrollTo({ top: 0, behavior: 'smooth' });
+				}
 			});
-		} else {
-			window.scrollTo({ top: 0, behavior: 'smooth' });
-		}
+		});
 	}
 
 	const commands: Command[] = [
@@ -139,13 +147,12 @@
 		});
 	}
 
-	// Reset + focus when opened; clamp selection when the list refilters
+	// Reset state when opened; clamp selection when the list refilters
 	$effect(() => {
 		if (palette.open) {
 			query = '';
 			activeIndex = 0;
 			copied = false;
-			requestAnimationFrame(() => inputEl?.focus());
 		}
 	});
 
@@ -188,7 +195,7 @@
 			<div class="flex items-center gap-3 px-4 border-b border-line">
 				<span class="font-mono text-accent text-sm select-none" aria-hidden="true">&gt;</span>
 				<input
-					bind:this={inputEl}
+					use:autofocus
 					bind:value={query}
 					type="text"
 					placeholder="Type a command or search…"


### PR DESCRIPTION
## Summary

Fixes ⌘K palette navigation not updating the URL to the selected section/page, plus two reliability issues found while verifying:

- **URL**: navigate with the full path (hash included) — previously the hash was stripped, so `/#about` landed as `/`, and same-page jumps never touched the URL
- **Scroll race**: SvelteKit's `noScroll` restoration runs a frame after `goto` resolves and was cancelling the smooth scroll on same-page section jumps; the manual scroll now waits it out (double rAF)
- **Lost keystrokes**: the input focused via `requestAnimationFrame`, which could fire late while the browser was busy (e.g. mid smooth-scroll) — first keystrokes hit `body`, leaving the default command selected and executing the wrong one. Now focuses synchronously on mount.

## Verification

7-case Playwright suite × 3 runs, all passing: same-page hash (URL + scroll), cross-page hash, page routes, re-selecting the section already in the URL, and home resetting to `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)